### PR TITLE
Removing request for services on connect for Android

### DIFF
--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -71,7 +71,6 @@ public class Peripheral extends BluetoothGattCallback {
 
 	private final Queue<Runnable> commandQueue = new ConcurrentLinkedQueue<>();
 	private final Handler mainHandler = new Handler(Looper.getMainLooper());
-	private Runnable discoverServicesRunnable;
 	private boolean commandQueueBusy = false;
 
 	private List<byte[]> writeQueue = new ArrayList<>();
@@ -289,10 +288,6 @@ public class Peripheral extends BluetoothGattCallback {
 	}
 	
 	private void handleDisconnect() {
-		if (discoverServicesRunnable != null) {
-			mainHandler.removeCallbacks(discoverServicesRunnable);
-			discoverServicesRunnable = null;
-		}
 
 		boolean canceledCommand = false;
 
@@ -365,18 +360,6 @@ public class Peripheral extends BluetoothGattCallback {
 			connecting = false;
 			if (newState == BluetoothProfile.STATE_CONNECTED && status == BluetoothGatt.GATT_SUCCESS) {
 				connected = true;
-
-				discoverServicesRunnable = new Runnable() {
-					@Override
-					public void run() {
-						if (gatt != null) {
-							gatt.discoverServices();
-						}
-						discoverServicesRunnable = null;
-					}
-				};
-
-				mainHandler.post(discoverServicesRunnable);
 
 				sendConnectionEvent(device, "BleManagerConnectPeripheral", status);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ble-manager",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "A BLE module for react native.",
   "main": "BleManager",
   "types": "./index.d.ts",


### PR DESCRIPTION
Removing request for services on connect for Android to maintain consistency with iOS and prevent bug which breaks operations on connection start