### PR TITLE
Null ios notify

### DIFF
--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -145,7 +145,8 @@ bool hasListeners;
             [self completedCommand];
         } else {
             if (hasListeners) {
-                [self sendEventWithName:@"BleManagerDidUpdateValueForCharacteristic" body:@{@"peripheral": peripheral.uuidAsString, @"characteristic":characteristic.UUID.UUIDString, @"service":characteristic.service.UUID.UUIDString, @"value": ([characteristic.value length] > 0) ? [characteristic.value toArray] : [NSNull null]}];
+                NSArray *notifyValue = characteristic.value ? [characteristic.value toArray] : @[];
+                [self sendEventWithName:@"BleManagerDidUpdateValueForCharacteristic" body:@{@"peripheral": peripheral.uuidAsString, @"characteristic":characteristic.UUID.UUIDString, @"service":characteristic.service.UUID.UUIDString, @"value": notifyValue}];
             }
         }
     });


### PR DESCRIPTION
- Empty notifies are iOS now emit empty array rather than null